### PR TITLE
Add Stremio theme colors

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -6,25 +6,32 @@
 
 /* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary: #2e8555;
-  --ifm-color-primary-dark: #29784c;
-  --ifm-color-primary-darker: #277148;
-  --ifm-color-primary-darkest: #205d3b;
-  --ifm-color-primary-light: #33925d;
-  --ifm-color-primary-lighter: #359962;
-  --ifm-color-primary-lightest: #3cad6e;
+  /**
+  * Stremio theme color from: https://github.com/Stremio/stremio-web/blob/development/src%2FApp%2Fstyles.less#L35.
+  */
+  --primary-accent-color: #7B5BF5;
+
+  /**
+  * Infima theme colors.
+  */
+  --ifm-color-primary: var(--primary-accent-color);
+  --ifm-color-primary-light: var(--primary-accent-color);
+  --ifm-color-primary-lighter: var(--primary-accent-color);
+  --ifm-color-primary-lightest: var(--primary-accent-color);
+  --ifm-color-primary-dark: #623bf3;
+  --ifm-color-primary-darker: #552bf2;
+  --ifm-color-primary-darkest: #390ede;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme='dark'] {
-  --ifm-color-primary: #25c2a0;
-  --ifm-color-primary-dark: #21af90;
-  --ifm-color-primary-darker: #1fa588;
-  --ifm-color-primary-darkest: #1a8870;
-  --ifm-color-primary-light: #29d5b0;
-  --ifm-color-primary-lighter: #32d8b4;
-  --ifm-color-primary-lightest: #4fddbf;
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+  --ifm-color-primary: #947bf7;
+  --ifm-color-primary-dark: #8c71f6;
+  --ifm-color-primary-darker: #896df6;
+  --ifm-color-primary-darkest: #866af6;
+  --ifm-color-primary-light: #b09ef9;
+  --ifm-color-primary-lighter: #beaffa;
+  --ifm-color-primary-lightest: #e9e4fd;
 }


### PR DESCRIPTION
Added the iconic purple as the primary color (mostly links and badges have this color). The colors are slightly lighter in dark mode in order to achieve a better contrast with the dark background color.

See: https://docusaurus.io/docs/styling-layout/#styling-your-site-with-infima for more information.